### PR TITLE
Fixed trackers link in popup UI

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -108,7 +108,7 @@
         "message": "Privacy Badger für diese Webseite aktivieren"
     },
     "popup_instructions": {
-        "message": "potenzielle <a target='_blank' href='https://www.eff.org/privacybadger#trackers'>Tracker</a> auf dieser Seite. Diese Schieberegler kontrollieren, wie Privacy Badger die einzelnen gefundenen Tracker handhabt. Sofern keine Probleme beim Laden dieser Webseite aufgetreten sind, sollte es nicht nötig sein, die Schieberegler anzupassen."
+        "message": "potenzielle <a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>Tracker</a> auf dieser Seite. Diese Schieberegler kontrollieren, wie Privacy Badger die einzelnen gefundenen Tracker handhabt. Sofern keine Probleme beim Laden dieser Webseite aufgetreten sind, sollte es nicht nötig sein, die Schieberegler anzupassen."
     },
     "popup_noblocked": {
         "message": "Warum wird nichts blockiert?"

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -108,7 +108,7 @@
         "message": "Enable Privacy Badger for This Site"
     },
     "popup_instructions": {
-        "message": "potential <a target='_blank' href='https://www.eff.org/privacybadger#trackers'>trackers</a> on this page. These sliders let you control how Privacy Badger handles each one. You shouldn't need to adjust them unless something is broken."
+        "message": "potential <a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>trackers</a> on this page. These sliders let you control how Privacy Badger handles each one. You shouldn't need to adjust them unless something is broken."
     },
     "popup_noblocked": {
         "message": "Why isn't anything blocked?"

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -102,7 +102,7 @@
         "message": "Habilitar Privacy Badger para este sitio"
     },
     "popup_instructions": {
-        "message": "potenciales <a target='_blank' href='https://www.eff.org/privacybadger#trackers'>rastreadores</a> en esta página. Estos controles deslizante te permitirán controlar cómo Privacy Badger maneja cada uno."
+        "message": "potenciales <a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>rastreadores</a> en esta página. Estos controles deslizante te permitirán controlar cómo Privacy Badger maneja cada uno."
     },
     "popup_noblocked": {
         "message": "¿Por qué no hay nada bloqueado?"

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -108,7 +108,7 @@
         "message": "Attiva Privacy Badger in questo sito"
     },
     "popup_instructions": {
-        "message": "potenziali <a target='_blank' href='https://www.eff.org/privacybadger#trackers'>tracker</a> in questa pagina. Con questi interruttori puoi controllare come Privacy Badger tratta ciascun tracker. Non dovresti averne bisogno a meno che qualcosa non funzioni male."
+        "message": "potenziali <a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>tracker</a> in questa pagina. Con questi interruttori puoi controllare come Privacy Badger tratta ciascun tracker. Non dovresti averne bisogno a meno che qualcosa non funzioni male."
     },
     "popup_noblocked": {
         "message": "Perchè non c'è niente di bloccato?"

--- a/src/_locales/nb_NO/messages.json
+++ b/src/_locales/nb_NO/messages.json
@@ -108,7 +108,7 @@
         "message": "Skru på Personvernsgrevlingen for denne siden"
     },
     "popup_instructions": {
-        "message": "potensielle <a target='_blank' href='https://www.eff.org/privacybadger#trackers'>sporere</a> på denne siden. Disse glidebryterne lar deg kontrollere hvordan Personvernsgrevlingen behandler hver av dem. Du skal ikke trenge å bruke dem hvis ikke noe har gått galt."
+        "message": "potensielle <a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>sporere</a> på denne siden. Disse glidebryterne lar deg kontrollere hvordan Personvernsgrevlingen behandler hver av dem. Du skal ikke trenge å bruke dem hvis ikke noe har gått galt."
     },
     "popup_noblocked": {
         "message": "Hvorfor blokkeres ikke noe?"

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -102,7 +102,7 @@
         "message": "Schakel Privacy Badger in op deze webpagina"
     },
     "popup_instructions": {
-        "message": "potentiële <a target='_blank' href='https://www.eff.org/privacybadger#trackers'>trackers</a> op deze webpagina. Met de schuifbalkjes kunt u instellen hoe Privacy Badger omgaat met een tracker."
+        "message": "potentiële <a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>trackers</a> op deze webpagina. Met de schuifbalkjes kunt u instellen hoe Privacy Badger omgaat met een tracker."
     },
     "popup_noblocked": {
         "message": "Waarom wekt blokkeren niet?"

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -105,7 +105,7 @@
         "message": "Включить Privacy Badger для этого сайта"
     },
     "popup_instructions": {
-        "message": "потенциальных <a target='_blank' href='https://www.eff.org/privacybadger#trackers'>трекеров</a> на этой странице. С помощью этих переключателей вы можете выбрать, какое действие Privacy Badger выполнит с каждым из них. Их нужно регулировать только в случае проблем с работой сайта."
+        "message": "потенциальных <a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>трекеров</a> на этой странице. С помощью этих переключателей вы можете выбрать, какое действие Privacy Badger выполнит с каждым из них. Их нужно регулировать только в случае проблем с работой сайта."
     },
     "popup_noblocked": {
         "message": "Почему ничего не заблокировано?"

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -108,7 +108,7 @@
         "message": "Омогући Privacy Badger на овом сајту"
     },
     "popup_instructions": {
-        "message": "могући <a target='_blank' href='https://www.eff.org/privacybadger#trackers'>пратиоци</a> на овом сајту. Ови клизачи вам омогућују да контролишете како да Privacy Badger рукује сваким од њих. Не би требало да их подешавате осим ако нешто није покварено."
+        "message": "могући <a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>пратиоци</a> на овом сајту. Ови клизачи вам омогућују да контролишете како да Privacy Badger рукује сваким од њих. Не би требало да их подешавате осим ако нешто није покварено."
     },
     "popup_noblocked": {
         "message": "Зашто ништа није блокирано?"

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -108,7 +108,7 @@
         "message": "Aktivera Privacy Badger för denna sida"
     },
     "popup_instructions": {
-        "message": "<a target='_blank' href='https://www.eff.org/privacybadger#trackers'>spanare</a> på denna sida. Dessa reglage låter dig bestämma hur Privacy Badger hanterar varje spanare."
+        "message": "<a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>spanare</a> på denna sida. Dessa reglage låter dig bestämma hur Privacy Badger hanterar varje spanare."
     },
     "popup_noblocked": {
         "message": "Varför är inget blockerat?"

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -108,7 +108,7 @@
         "message": "Увімкнути Privacy Badger для цього сайту"
     },
     "popup_instructions": {
-        "message": "можливе <a target='_blank' href='https://www.eff.org/privacybadger#trackers'>стеження</a> на цій сторінці. Ці перемикачі дозволяють вам контролювати, як Privacy Badger обробляє їх. Вам не потрібно змінювати їх, доки щось на сторінці не буде пошкоджено."
+        "message": "можливе <a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>стеження</a> на цій сторінці. Ці перемикачі дозволяють вам контролювати, як Privacy Badger обробляє їх. Вам не потрібно змінювати їх, доки щось на сторінці не буде пошкоджено."
     },
     "popup_noblocked": {
         "message": "Чому не блокується будь-що?"

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -108,7 +108,7 @@
         "message": "在当前的网页上启用隐私獾"
     },
     "popup_instructions": {
-        "message": "在这个网站上有潜在的<a target='_blank' href='https://www.eff.org/privacybadger#trackers'>跟踪器</a> 。这些滑块让你控制隐私獾如何处理每一个跟踪器。你不必调整他们，除非隐私獾造成网页显示异常。"
+        "message": "在这个网站上有潜在的<a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>跟踪器</a> 。这些滑块让你控制隐私獾如何处理每一个跟踪器。你不必调整他们，除非隐私獾造成网页显示异常。"
     },
     "popup_noblocked": {
         "message": "为什么没有任何东西被屏蔽？"

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -117,7 +117,7 @@
         "message": "在目前網頁開啟 Privacy Badger"
     },
     "popup_instructions": {
-        "message": "可疑的<a target='_blank' href='https://www.eff.org/privacybadger#trackers'>追蹤器</a>。<br>這些滾動條讓您可控制 Privacy Badger 如何處理每一個追蹤器，但除非 Privacy Badger 造成網頁顯示異常，不必特別調整。"
+        "message": "可疑的<a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>追蹤器</a>。<br>這些滾動條讓您可控制 Privacy Badger 如何處理每一個追蹤器，但除非 Privacy Badger 造成網頁顯示異常，不必特別調整。"
     },
     "popup_noblocked": {
         "message": "為什麼沒有封鎖任何東西？"


### PR DESCRIPTION
Corrected the link from the "trackers" word in the popup UI to the Privacy
Badger website. Should solve issue #1301.